### PR TITLE
Sets custom configuration for Pantheon environments

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -1,0 +1,17 @@
+---
+api_version: 1
+
+# PHP Version:
+# https://pantheon.io/docs/pantheon-yml#php-version
+php_version: 7.0
+
+# Protected Web Paths
+# https://pantheon.io/docs/pantheon-yml#protected-web-paths
+protected_web_paths:
+   - /README.md
+   - /README.txt
+   - /LICENSE.txt
+   - /web.config
+   - /example.gitignore
+   - /composer.json
+   - /composer.lock


### PR DESCRIPTION
The main purpose here is to set the PHP version to PHP7. We are also making the documentation
files unreachable for limited security purposes.
